### PR TITLE
New feat: load database url parameter from dotenv file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 eddn = "0.1.0"
-clap = { version = "4.5.20", features = ["derive"] }
+clap = { version = "4.5.20", features = ["derive", "env"] }
 env_logger = "0.11.5"
 log = "0.4.22"
 edsm-dumps-model = "0.9.1"
@@ -21,3 +21,4 @@ num-format = "0.4.4"
 # not on crates.io for some reason
 num2english = { git = "https://github.com/trvswgnr/num2english", branch = "main" }
 serde = { version = "1.0.217", features = ["derive"] }
+dotenvy = { version = "0.15.7"}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ See some interesting statistics about the data, once collected:
 cargo run --release -- stats --url postgres://postgres:password@localhost/edtear
 ```
 
+If no url is supplied EDTear will default to the environment variable `DATABASE_URL` supplied within `.env`:
+```
+DATABASE_URL=postgres://postgres:password@localhost/edtear
+```
+
 ## Running in Docker Compose
 Once you've set up the database locally, you can also run EDTear through Docker Compose, which may be useful
 for server deployments.

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ enum Commands {
         #[arg(long)]
         /// Path to stations JSON from EDSM
         stations_json_path: std::path::PathBuf,
-        #[arg(long)]
+        #[arg(long, env = "DATABASE_URL")]
         /// Postgres connection URL. Recommended: postgres://postgres:password@localhost/edtear
         url: String,
     },
@@ -40,21 +40,21 @@ enum Commands {
         /// Path to galaxy stations JSON from Spansh's website
         #[arg(long)]
         galaxy_stations_json_path: std::path::PathBuf,
-        #[arg(long)]
+        #[arg(long, env = "DATABASE_URL")]
         /// Postgres connection URL. Recommended: postgres://postgres:password@localhost/edtear
         url: String,
     },
 
     /// Listens to EDDN to receive updated commodity data
     Listen {
-        #[arg(long)]
+        #[arg(long, env = "DATABASE_URL")]
         /// Postgres connection URL. Recommended: postgres://postgres:password@localhost/edtear
         url: String,
     },
 
     /// Displays statistics for a connected database
     Stats {
-        #[arg(long)]
+        #[arg(long, env = "DATABASE_URL")]
         /// Postgres connection URL. Recommended: postgres://postgres:password@localhost/edtear
         url: String,
     },
@@ -66,6 +66,7 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    dotenvy::dotenv_override()?;
     let args = EdTearCli::parse();
     env_logger::init();
     color_eyre::install()?;


### PR DESCRIPTION
Additional dependencies: 
- dotenvy
- clap --feature env

Load envvars from the .env file with in the current dir and override existing envvars if they exist (`dotenvy`).
Use `DATABASE_URL` envvar if the `--url` argument isn't passed to the subcommand